### PR TITLE
Add initialization helper and tests

### DIFF
--- a/__tests__/initializeLoveTimer.test.js
+++ b/__tests__/initializeLoveTimer.test.js
@@ -1,0 +1,48 @@
+import { jest } from '@jest/globals';
+import { screen } from '@testing-library/dom';
+
+// Prevent CSS imports from breaking tests for ESM
+jest.unstable_mockModule('../src/style.css', () => ({}));
+
+let LoveTimerApp;
+let initializeLoveTimer;
+
+beforeAll(async () => {
+  const mod = await import('../src/main.js');
+  LoveTimerApp = mod.LoveTimerApp;
+  initializeLoveTimer = mod.initializeLoveTimer;
+});
+
+describe('initializeLoveTimer', () => {
+  test('instantiates LoveTimerApp and calls init', () => {
+    const initSpy = jest.spyOn(LoveTimerApp.prototype, 'init').mockImplementation(() => {
+      // set flag so we know this method was called on instance
+      return undefined;
+    });
+
+    const timer = initializeLoveTimer();
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    expect(timer).toBeInstanceOf(LoveTimerApp);
+    expect(window.loveTimer).toBe(timer);
+
+    initSpy.mockRestore();
+  });
+});
+
+describe('updateTheme', () => {
+  beforeEach(() => {
+    document.documentElement.setAttribute('data-theme', '');
+  });
+
+  test('applies theme to document', () => {
+    const app = new LoveTimerApp();
+    const status = document.createElement('span');
+    app.cachedElements.themeStatus = status;
+    app.currentTheme = 'light';
+    app.updateTheme();
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(status.textContent).toBeTruthy();
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -836,16 +836,22 @@ export class LoveTimerApp {
   }
 }
 
+// Initialize the application and expose the instance
+export function initializeLoveTimer() {
+  const timer = new LoveTimerApp();
+  timer.init();
+
+  if (typeof window !== 'undefined') {
+    window.loveTimer = timer;
+  }
+
+  return timer;
+}
+
 // Initialize the application when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
   try {
-    const timer = new LoveTimerApp();
-    timer.init();
-
-    // Make timer globally available for debugging
-    if (typeof window !== 'undefined') {
-      window.loveTimer = timer;
-    }
+    initializeLoveTimer();
   } catch (error) {
     console.error('Failed to initialize Love Timer:', error);
 


### PR DESCRIPTION
## Summary
- export `initializeLoveTimer` helper and reuse it when DOM loads
- test initialization helper and theme updates

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68406a9bc97c8331b7c3ee9f1080484e