### PR TITLE
Update entry point docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ Access at: `http://localhost:3000`.
 
 ## Entry Point
 
-The timer boots via **`initializeLoveTimer`** exported from `src/main.js`. This
-function constructs a `LoveTimerApp`, triggers its `init()` routine, and returns
-the created instance. It also runs automatically on `DOMContentLoaded`, placing
-the instance on `window.loveTimer` for debugging. The core logic is split across
-three supporting modules:
+The global entry point is **`initializeLoveTimer`** exported from
+`src/main.js`. This helper instantiates a `LoveTimerApp`, invokes its
+`init()` routine, and exposes the resulting instance as `window.loveTimer` once
+the page has loaded. Timer logic now lives in dedicated modules:
 
-- **`timer.js`** – keeps track of elapsed time and fires anniversary events.
-- **`theme.js`** – applies light or dark mode and remembers the user's choice.
-- **`ui.js`** – updates the DOM and wires up button clicks and keyboard input.
+- **`timer.js`** – tracks elapsed time and fires anniversary events.
+- **`theme.js`** – handles theme selection and stores the user's preference.
+- **`ui.js`** – updates the DOM and wires up user interactions.
+
 
 ---
 
@@ -107,14 +107,13 @@ This project is configured for use with AI coding assistants like OpenAI Codex:
     -   `npm run test`: For running automated tests.
     -   `npm run lint`: For code linting.
 -   **Setup Script (`setup.sh`)**: Automates the installation of dependencies and generation of necessary configuration files (`tsconfig.json`, `.eslintrc.json`, etc.).
--   **Inline Code Tags (`@codex:`)**: Present in `src/main.js` to help agents identify key code sections.
 
 ---
 
 ## Code Structure
 
-- **`src/main.js`**: Hosts `LoveTimerApp` and exports `initializeLoveTimer`, the helper that instantiates and starts the app.
-- **`src/timer.js`**: Provides the core timekeeping utilities and emits anniversary events.
+- **`src/main.js`**: Hosts `LoveTimerApp` and exports `initializeLoveTimer`, the global entry point that sets up and launches the timer.
+- **`src/timer.js`**: Contains the core timer logic and emits anniversary events.
 - **`src/theme.js`**: Controls theme selection and persists the user's preference.
 - **`src/ui.js`**: Handles DOM manipulation and user interactions.
 


### PR DESCRIPTION
## Summary
- clarify that initializeLoveTimer is the global entry point
- list the timer, theme and UI helper modules
- remove mention of obsolete @codex tags

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6840755d1abc83319f824799d301ffe4