### PR TITLE
Add cleanup for matchMedia listeners

### DIFF
--- a/__tests__/loveTimerApp.test.js
+++ b/__tests__/loveTimerApp.test.js
@@ -89,3 +89,49 @@ describe('LoveTimerApp utility methods', () => {
     });
   });
 });
+
+describe('event listener cleanup', () => {
+  let originalMatchMedia;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('removes matchMedia listeners on cleanup', () => {
+    const darkQuery = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      matches: false
+    };
+    const motionQuery = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      matches: false
+    };
+
+    window.matchMedia = jest.fn((q) =>
+      q.includes('color-scheme') ? darkQuery : motionQuery
+    );
+
+    const app = new LoveTimerApp();
+    app.setupEventListeners();
+
+    expect(darkQuery.addEventListener).toHaveBeenCalledTimes(1);
+    expect(motionQuery.addEventListener).toHaveBeenCalledTimes(1);
+
+    app.cleanup();
+
+    expect(darkQuery.removeEventListener).toHaveBeenCalledWith(
+      'change',
+      app.handleDarkModeChange
+    );
+    expect(motionQuery.removeEventListener).toHaveBeenCalledWith(
+      'change',
+      app.handleReducedMotionChange
+    );
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -39,6 +39,12 @@ export class LoveTimerApp {
     this.dateFormatter = null;
     this.messages = [];
 
+    // MatchMedia queries and handlers
+    this.darkModeQuery = null;
+    this.reducedMotionQuery = null;
+    this.handleDarkModeChange = null;
+    this.handleReducedMotionChange = null;
+
     // Bind methods to preserve context
     this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
     this.handleKeydown = this.handleKeydown.bind(this);
@@ -181,14 +187,17 @@ export class LoveTimerApp {
 
     // Theme system preference changes
     if (window.matchMedia) {
-      const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      darkModeQuery.addEventListener('change', () => updateTheme(this));
+      this.darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      this.handleDarkModeChange = () => updateTheme(this);
+      this.darkModeQuery.addEventListener('change', this.handleDarkModeChange);
 
-      const reducedMotionQuery = window.matchMedia(
+      this.reducedMotionQuery = window.matchMedia(
         '(prefers-reduced-motion: reduce)'
       );
-      reducedMotionQuery.addEventListener('change', () =>
-        updateAnimationPreference(this)
+      this.handleReducedMotionChange = () => updateAnimationPreference(this);
+      this.reducedMotionQuery.addEventListener(
+        'change',
+        this.handleReducedMotionChange
       );
     }
 
@@ -829,6 +838,20 @@ export class LoveTimerApp {
     );
     document.removeEventListener('keydown', this.handleKeydown);
     window.removeEventListener('beforeunload', this.handleBeforeUnload);
+
+    if (this.darkModeQuery && this.handleDarkModeChange) {
+      this.darkModeQuery.removeEventListener(
+        'change',
+        this.handleDarkModeChange
+      );
+    }
+
+    if (this.reducedMotionQuery && this.handleReducedMotionChange) {
+      this.reducedMotionQuery.removeEventListener(
+        'change',
+        this.handleReducedMotionChange
+      );
+    }
 
     console.log('Love Timer cleaned up');
   }


### PR DESCRIPTION
## Summary
- store matchMedia queries and their handlers in `LoveTimerApp`
- register and remove these listeners in `setupEventListeners` and `cleanup`
- test that cleanup removes the listeners

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684094adeeec83318ce9dbbfa7b59205